### PR TITLE
ci: add smoke checks workflow and README badge

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -1,0 +1,45 @@
+name: CI Smoke Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bash syntax check
+        run: bash -n scripts/gdm_network_lockdown.sh
+
+      - name: Usage output check
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$(bash scripts/gdm_network_lockdown.sh 2>&1 || true)"
+          echo "$output"
+          grep -Fq "Usage:" <<<"$output"
+          grep -Fq "./gdm_network_lockdown.sh lock" <<<"$output"
+          grep -Fq "./gdm_network_lockdown.sh revert" <<<"$output"
+          grep -Fq "./gdm_network_lockdown.sh status" <<<"$output"
+
+      - name: Verify release artifacts on tags
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          test -f dist/gdm_network_lockdown.sh
+          test -f dist/gdm_network_lockdown.sh.sha256
+          test -f "dist/popos-radio-lockdown-minimal-${tag}.tar.gz"
+          test -f "dist/popos-radio-lockdown-minimal-${tag}.tar.gz.sha256"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Pop!_OS Radio Lockdown (Lockout/Logout)
+[![CI Smoke Checks](https://github.com/angelcamach0/popos-radio-lockdown/actions/workflows/ci-smoke.yml/badge.svg)](https://github.com/angelcamach0/popos-radio-lockdown/actions/workflows/ci-smoke.yml)
 
 Purpose: enforce Wi-Fi/WWAN/Bluetooth OFF on lock screen and logout/greeter, then restore ON after successful unlock/login.
 


### PR DESCRIPTION
Fixes #1

## Summary
- add new GitHub Actions workflow: `.github/workflows/ci-smoke.yml`
- run shell syntax validation: `bash -n scripts/gdm_network_lockdown.sh`
- verify usage output contains expected subcommands (`lock`, `revert`, `status`)
- on version tags (`v*`), verify expected release artifacts exist in `dist/`
- add workflow status badge to `README.md`

## Trigger behavior
- pull requests
- pushes to all branches
- version tags matching `v*`
- manual run via `workflow_dispatch`

## Local validation
- `bash -n scripts/gdm_network_lockdown.sh`
- usage check grep for required subcommands
